### PR TITLE
update codesign instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To add this entitlement to your project, you'll first need a certificate chain t
 You can now sign binaries and add entitlements using the following command:
 
 ```
-codesign --entitlements entitlements.xml -s ${CERT_NAME} /path/to/binary
+codesign --entitlements entitlements.xml -f -s ${CERT_NAME} /path/to/binary
 ```
 
 **Note:** The `entitlements.xml` file is available at the root of the Applevisor repository.
@@ -94,7 +94,7 @@ cargo build --release
 Sign the binary and grant the hypervisor entitlement.
 
 ```
-codesign --entitlements entitlements.xml -s ${CERT_NAME} target/release/${PROJECT_NAME}
+codesign --entitlements entitlements.xml -f -s ${CERT_NAME} target/release/${PROJECT_NAME}
 ```
 
 Run the binary.


### PR DESCRIPTION
`codesign` requires the -f flag to overwrite existing signatures

After a normal `cargo build --release` the resulting binary is already signed. I can't tell if this is new behavior (I'm using 1.77.1 nightly), but the `-f` flag for codesign should be perfectly fine for binaries with or without signatures already